### PR TITLE
feat(005): Owen swim wake-up — weekday guard + Alexa vswitch

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -5946,13 +5946,20 @@
 
         '
   mode: single
-- id: '1750731652197'
+- id: ‘1750731652197’
   alias: "\U0001F3CA‍♂️ Owen not awake for early swim"
-  description: ''
+  description: ‘’
   trigger:
   - platform: time
     at: 04:50:00
   condition:
+  - condition: time
+    weekday:
+    - mon
+    - tue
+    - wed
+    - thu
+    - fri
   - type: is_not_occupied
     condition: device
     device_id: 236765636ad6b4830327b44e7b9ab4ca
@@ -5962,9 +5969,6 @@
       hours: 0
       minutes: 5
       seconds: 0
-  - condition: state
-    entity_id: input_boolean.owen_on_wifi
-    state: 'on'
   action:
   - service: notify.mobile_app_iphone703
     metadata: {}
@@ -5972,6 +5976,14 @@
       message: "\U0001F4A4 Owen hasn’t woke up!"
       data:
         sound: alarm-clock.wav
+  - service: input_boolean.turn_on
+    target:
+      entity_id: input_boolean.vswitch_announce_owen_swim_wake_up
+  - delay:
+      seconds: 5
+  - service: input_boolean.turn_off
+    target:
+      entity_id: input_boolean.vswitch_announce_owen_swim_wake_up
   mode: single
 - id: '1719273830000'
   alias: Set Ecobee to Home mode - Tuesday return from swim meets

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1187,6 +1187,11 @@ input_boolean:
     initial: off
     icon: mdi:amazon-alexa
 
+  vswitch_announce_owen_swim_wake_up:
+    name: "🏊‍♂️🔵 VSwitch Announce Owen Swim Wake Up"
+    initial: off
+    icon: mdi:swim
+
   alexa_maggie_monitor:
     name: Alexa Maggie Monitor
     initial: off


### PR DESCRIPTION
## Summary
- Adds `input_boolean.vswitch_announce_owen_swim_wake_up` entity to `configuration.yaml`
- Restricts the "🏊‍♂️ Owen not awake for early swim" automation to Mon–Fri only (removes weekend false alerts)
- Removes `owen_on_wifi` condition (no longer needed per spec)
- Pulses the vswitch on for 5 seconds then off so Alexa can trigger an announcement routine

## Feature File
`features/005-owen-swim-wake-up-weekday-vswitch.md`

## Test Plan
- [ ] Reload HA configuration and confirm `input_boolean.vswitch_announce_owen_swim_wake_up` appears in entity list
- [ ] Expose the new entity to Alexa via the Alexa integration
- [ ] Create Alexa routine: trigger = vswitch turns on → action = announcement
- [ ] On a weekday, manually trigger the automation → phone notification fires + vswitch pulses on/off
- [ ] On a weekend, confirm automation does not fire